### PR TITLE
feat: support counting AI agent coding input as merit

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,25 @@
             "zh-CN"
           ],
           "description": "Display language (auto follows VS Code language)"
+        },
+        "codezen.agent.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Count AI agent / multi-character input as merit"
+        },
+        "codezen.agent.weight": {
+          "type": "number",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 1000,
+          "description": "Characters per 1 merit for AI agent input (e.g. 10 = 1 merit per 10 characters)"
+        },
+        "codezen.agent.maxPerMinute": {
+          "type": "number",
+          "default": 600,
+          "minimum": 1,
+          "maximum": 10000,
+          "description": "Maximum agent merit per minute (rate limit)"
         }
       }
     }

--- a/src/anticheat.ts
+++ b/src/anticheat.ts
@@ -2,11 +2,27 @@
  * Anti-cheat module for merit counting.
  *
  * Rules:
- * - Only single-character inputs count (no paste / autocomplete bulk inserts)
+ * - Single-character inputs count as 1 merit (human typing)
+ * - Multi-character inputs (AI agent / paste) count with configurable weight
  * - Same key repeated rapidly → decay (diminishing returns)
- * - Per-minute cap to block key-repeat macros
+ * - Per-minute caps to block macros / abuse
  * - Backspace/delete don't affect merit (慈悲为怀)
  */
+
+export interface AgentMeritConfig {
+  /** Whether to count multi-character (agent) input. Default: true */
+  enabled: boolean;
+  /** Characters per 1 merit for agent input. Default: 10 */
+  weight: number;
+  /** Per-minute merit cap for agent input. Default: 600 */
+  maxPerMinute: number;
+}
+
+const DEFAULT_AGENT_CONFIG: AgentMeritConfig = {
+  enabled: true,
+  weight: 10,
+  maxPerMinute: 600,
+};
 
 export class AntiCheat {
   private lastChar: string = '';
@@ -14,17 +30,34 @@ export class AntiCheat {
   private minuteMerit: number = 0;
   private minuteStart: number = Date.now();
 
+  // Agent-specific rate limiting
+  private agentMinuteMerit: number = 0;
+  private agentMinuteStart: number = Date.now();
+
+  private agentConfig: AgentMeritConfig;
+
   // Configurable limits
   private readonly MAX_PER_MINUTE = 300; // ~5 chars/sec sustained = fast typist
   private readonly REPEAT_DECAY_START = 5; // after 5 same-char, start decaying
   private readonly REPEAT_DECAY_FACTOR = 0.5;
 
+  constructor(agentConfig?: Partial<AgentMeritConfig>) {
+    this.agentConfig = { ...DEFAULT_AGENT_CONFIG, ...agentConfig };
+  }
+
   /**
-   * Returns merit value (0 or 1) for a text change event.
+   * Update agent merit configuration at runtime (e.g. when settings change).
+   */
+  updateAgentConfig(config: Partial<AgentMeritConfig>): void {
+    this.agentConfig = { ...this.agentConfig, ...config };
+  }
+
+  /**
+   * Returns merit value for a single-character (human typing) text change.
    * Returns 0 if the input should not count.
    */
   evaluate(insertedText: string): number {
-    // Only single character inputs count
+    // Only single character inputs count as human typing
     if (insertedText.length !== 1) {
       return 0;
     }
@@ -54,6 +87,44 @@ export class AntiCheat {
     if (merit > 0) {
       this.minuteMerit++;
     }
+    return merit;
+  }
+
+  /**
+   * Returns merit value for multi-character (AI agent / paste) text changes.
+   * Merit = floor(charCount / weight), subject to per-minute cap.
+   * Returns 0 if agent merit is disabled or input is too short.
+   */
+  evaluateAgent(insertedText: string): number {
+    if (!this.agentConfig.enabled) {
+      return 0;
+    }
+
+    // Must be multi-character to qualify as agent input
+    if (insertedText.length <= 1) {
+      return 0;
+    }
+
+    // Per-minute cap for agent merit
+    const now = Date.now();
+    if (now - this.agentMinuteStart > 60_000) {
+      this.agentMinuteMerit = 0;
+      this.agentMinuteStart = now;
+    }
+
+    const rawMerit = Math.floor(insertedText.length / this.agentConfig.weight);
+    if (rawMerit <= 0) {
+      return 0;
+    }
+
+    // Clamp to remaining per-minute budget
+    const remaining = this.agentConfig.maxPerMinute - this.agentMinuteMerit;
+    if (remaining <= 0) {
+      return 0;
+    }
+
+    const merit = Math.min(rawMerit, remaining);
+    this.agentMinuteMerit += merit;
     return merit;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { MeritStore } from './store';
-import { AntiCheat } from './anticheat';
+import { AntiCheat, AgentMeritConfig } from './anticheat';
 import { getRankForMerit, getRankTitle, getNextRank } from './ranks';
 import { getMessages, Messages } from './i18n';
 import { SoundPlayer } from './sound';
@@ -14,10 +14,11 @@ let soundPlayer: SoundPlayer;
 let muyuViewProvider: MuyuViewProvider;
 let updateTimer: ReturnType<typeof setTimeout> | undefined;
 let pendingMerit = 0;
+let pendingAgentMerit = 0;
 
 export function activate(context: vscode.ExtensionContext) {
   store = new MeritStore(context.globalState);
-  antiCheat = new AntiCheat();
+  antiCheat = new AntiCheat(getAgentConfig());
   soundPlayer = new SoundPlayer();
   muyuViewProvider = new MuyuViewProvider();
   context.subscriptions.push(
@@ -46,11 +47,22 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       for (const change of e.contentChanges) {
-        const merit = antiCheat.evaluate(change.text);
-        if (merit > 0) {
-          pendingMerit += merit;
-          muyuViewProvider.knock();
-          scheduleMeritFlush(context);
+        if (change.text.length === 1) {
+          // Human typing — single character
+          const merit = antiCheat.evaluate(change.text);
+          if (merit > 0) {
+            pendingMerit += merit;
+            muyuViewProvider.knock();
+            scheduleMeritFlush(context);
+          }
+        } else if (change.text.length > 1) {
+          // Multi-character input (AI agent, paste, autocomplete)
+          const agentMerit = antiCheat.evaluateAgent(change.text);
+          if (agentMerit > 0) {
+            pendingAgentMerit += agentMerit;
+            muyuViewProvider.knock();
+            scheduleMeritFlush(context);
+          }
         }
       }
     })
@@ -72,6 +84,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (e.affectsConfiguration('codezen')) {
         const cfg = vscode.workspace.getConfiguration('codezen');
         messages = getMessages(cfg.get<string>('locale', 'auto'));
+        antiCheat.updateAgentConfig(getAgentConfig());
         updateStatusBar();
       }
     })
@@ -90,20 +103,26 @@ function scheduleMeritFlush(context: vscode.ExtensionContext) {
   }
   updateTimer = setTimeout(async () => {
     updateTimer = undefined;
-    if (pendingMerit <= 0) {
+    if (pendingMerit <= 0 && pendingAgentMerit <= 0) {
       return;
     }
 
-    const oldRank = getRankForMerit(store.totalMerit);
-    await store.addMerit(pendingMerit);
-    pendingMerit = 0;
+    const oldRank = getRankForMerit(store.combinedMerit);
+    if (pendingMerit > 0) {
+      await store.addMerit(pendingMerit);
+      pendingMerit = 0;
+    }
+    if (pendingAgentMerit > 0) {
+      await store.addAgentMerit(pendingAgentMerit);
+      pendingAgentMerit = 0;
+    }
 
-    const newRank = getRankForMerit(store.totalMerit);
+    const newRank = getRankForMerit(store.combinedMerit);
     updateStatusBar();
 
     // Update muyu panel
     const rankTitle = getRankTitle(newRank, messages);
-    muyuViewProvider.updateMerit(store.totalMerit, rankTitle);
+    muyuViewProvider.updateMerit(store.combinedMerit, rankTitle);
 
     // Rank up notification
     if (newRank.level > oldRank.level) {
@@ -120,7 +139,7 @@ function scheduleMeritFlush(context: vscode.ExtensionContext) {
 function updateStatusBar() {
   const config = vscode.workspace.getConfiguration('codezen');
   const format = config.get<string>('statusBar.format', '🪵 {merit}');
-  const total = store.totalMerit + pendingMerit;
+  const total = store.combinedMerit + pendingMerit + pendingAgentMerit;
   const rank = getRankForMerit(total);
   const title = getRankTitle(rank, messages);
 
@@ -133,19 +152,23 @@ function updateStatusBar() {
 }
 
 function showMeritBook() {
-  const rank = getRankForMerit(store.totalMerit);
+  const combined = store.combinedMerit;
+  const rank = getRankForMerit(combined);
   const title = getRankTitle(rank, messages);
   const next = getNextRank(rank);
   let streak = '';
   if (next) {
-    const remaining = next.threshold - store.totalMerit;
+    const remaining = next.threshold - combined;
     const nextTitle = getRankTitle(next, messages);
     streak = `\nNext: ${nextTitle} (${remaining.toLocaleString()} more)`;
   } else {
     streak = '\n🎉 Maximum enlightenment achieved!';
   }
 
-  const text = messages.meritBook(store.totalMerit, title, store.todayMerit, streak);
+  const todayCombined = store.todayMerit + store.todayAgentMerit;
+  const text = messages.meritBook(combined, title, todayCombined, streak) +
+    `\n\n${messages.humanMerit}: ${store.totalMerit.toLocaleString()}` +
+    `\n${messages.agentMerit}: ${store.agentMerit.toLocaleString()}`;
   vscode.window.showInformationMessage(text, { modal: true });
 }
 
@@ -171,4 +194,13 @@ async function resetMerit() {
 
 export function deactivate() {
   soundPlayer?.dispose();
+}
+
+function getAgentConfig(): Partial<AgentMeritConfig> {
+  const config = vscode.workspace.getConfiguration('codezen');
+  return {
+    enabled: config.get<boolean>('agent.enabled', true),
+    weight: config.get<number>('agent.weight', 10),
+    maxPerMinute: config.get<number>('agent.maxPerMinute', 600),
+  };
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,8 @@
 // i18n messages for CodeZen
 export interface Messages {
   merit: string;
+  humanMerit: string;
+  agentMerit: string;
   rankUp: (rank: string) => string;
   meritBook: (merit: number, rank: string, today: number, streak: string) => string;
   resetConfirm: string;
@@ -12,6 +14,8 @@ export interface Messages {
 
 const en: Messages = {
   merit: 'Merit',
+  humanMerit: 'Human Merit',
+  agentMerit: 'Agent Merit',
   rankUp: (rank) => `Congratulations! You have ascended to "${rank}" 🙏`,
   meritBook: (merit, rank, today, streak) =>
     `📿 Merit Book\n\n` +
@@ -36,6 +40,8 @@ const en: Messages = {
 
 const zhCN: Messages = {
   merit: '功德',
+  humanMerit: '人工功德',
+  agentMerit: 'AI功德',
   rankUp: (rank) => `恭喜施主晋升「${rank}」🙏`,
   meritBook: (merit, rank, today, streak) =>
     `📿 功德簿\n\n` +

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,8 @@ const KEYS = {
   todayDate: 'codezen.todayDate',
   rankLevel: 'codezen.rankLevel',
   firstUseDate: 'codezen.firstUseDate',
+  agentMerit: 'codezen.agentMerit',
+  todayAgentMerit: 'codezen.todayAgentMerit',
 };
 
 export class MeritStore {
@@ -36,10 +38,30 @@ export class MeritStore {
     return this.state.get<string>(KEYS.firstUseDate, new Date().toISOString());
   }
 
+  get agentMerit(): number {
+    return this.state.get<number>(KEYS.agentMerit, 0);
+  }
+
+  get todayAgentMerit(): number {
+    this.rolloverDay();
+    return this.state.get<number>(KEYS.todayAgentMerit, 0);
+  }
+
+  /** Combined total of human + agent merit. */
+  get combinedMerit(): number {
+    return this.totalMerit + this.agentMerit;
+  }
+
   async addMerit(amount: number): Promise<void> {
     this.rolloverDay();
     await this.state.update(KEYS.totalMerit, this.totalMerit + amount);
     await this.state.update(KEYS.todayMerit, this.state.get<number>(KEYS.todayMerit, 0) + amount);
+  }
+
+  async addAgentMerit(amount: number): Promise<void> {
+    this.rolloverDay();
+    await this.state.update(KEYS.agentMerit, this.agentMerit + amount);
+    await this.state.update(KEYS.todayAgentMerit, this.state.get<number>(KEYS.todayAgentMerit, 0) + amount);
   }
 
   async setRankLevel(level: number): Promise<void> {
@@ -50,6 +72,8 @@ export class MeritStore {
     await this.state.update(KEYS.totalMerit, 0);
     await this.state.update(KEYS.todayMerit, 0);
     await this.state.update(KEYS.rankLevel, 1);
+    await this.state.update(KEYS.agentMerit, 0);
+    await this.state.update(KEYS.todayAgentMerit, 0);
     await this.state.update(KEYS.todayDate, this.getToday());
   }
 


### PR DESCRIPTION
## Summary
- Add configurable merit counting for multi-character (AI agent) input with `evaluateAgent()` method, per-char weight, and rate limiting
- Separate agent merit tracking in store with `agentMerit`/`todayAgentMerit` and `combinedMerit` getter
- New settings: `codezen.agent.enabled`, `codezen.agent.weight`, `codezen.agent.maxPerMinute`
- Merit book shows human vs agent breakdown with i18n support (en, zh-CN)

Closes https://github.com/frankliu20/codezen/issues/1

## Test plan
- [x] Enable `codezen.agent.enabled` and verify multi-char paste/agent input accumulates agent merit
- [x] Verify rate limiting respects `codezen.agent.maxPerMinute`
- [x] Verify `codezen.agent.weight` scales agent merit correctly
- [x] Verify merit book shows human vs agent breakdown
- [x] Verify disabling `codezen.agent.enabled` stops agent merit counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)