### PR TITLE
ci: add VS Code Marketplace publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,8 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           files: '*.vsix'
+
+      - name: Publish to VS Code Marketplace
+        run: npx @vscode/vsce publish --packagePath *.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Summary
- Add marketplace publish step to the existing release workflow
- Uses `VSCE_PAT` secret for authentication

## Setup required
Add the PAT as a repo secret:
**Settings → Secrets and variables → Actions → New repository secret**
- Name: `VSCE_PAT`
- Value: your Personal Access Token

## How it works
Push a tag (`v*`) → GitHub Actions builds → creates GitHub Release → publishes to Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)